### PR TITLE
Add missing failure tag: `failure-32` for `whitespace-within-word`

### DIFF
--- a/violations/whitespace-within-word.md
+++ b/violations/whitespace-within-word.md
@@ -2,6 +2,7 @@
 title: Whitespace Within Word
 tags: 
   - wcag-1-3-2
+  - failure-32
 linting: exists
 testing: exists
 author: couldexist


### PR DESCRIPTION
If merged, this PR adds the corresponding failure tag to the `no-whitespace-within-word` violation